### PR TITLE
Veto logging

### DIFF
--- a/lcls-twincat-pmps/Library/DUTs/ST_FFInfo.TcDUT
+++ b/lcls-twincat-pmps/Library/DUTs/ST_FFInfo.TcDUT
@@ -14,11 +14,7 @@ STRUCT
 ///////////////////////////////////////////
 // Warning, this variable is effectively a VETO of the fast fault if set FALSE
 // Do not alter the state of this variable unless you really know what you're doing.
-///////////////////////////////////////////    
-//    {attribute 'pytmc' := '
-//        pv: InUse
-//        io: i
-//     '}
+///////////////////////////////////////////
     InUse   :   BOOL := FALSE; // If this FF is currently in-use
 ///////////////////////////////////////////
 

--- a/lcls-twincat-pmps/Library/DUTs/ST_FFInfo.TcDUT
+++ b/lcls-twincat-pmps/Library/DUTs/ST_FFInfo.TcDUT
@@ -6,28 +6,9 @@
 
 TYPE ST_FFInfo :
 STRUCT
-//    {attribute 'pytmc' := '
-//    pv: FFPath
-//    io: i
-//     '}
     sPath   :    T_MaxString; // Full PLC path to FF object
-    
-//    {attribute 'pytmc' := '
-//        pv: Description
-//        io: i
-//     '}
     Desc    :   T_MaxString; // Set at instantiation to a helpful description of the fast fault purpose
-    
-//        {attribute 'pytmc' := '
-//        pv: DevName
-//        io: i
-//     '}
     DevName :   T_MaxString; // Component name, used in diagnostic to help narrow down where beam faults are coming from
-    
-//    {attribute 'pytmc' := '
-//        pv: TypeCode
-//        io: i
-//     '}
     TypeCode    :   UINT; // Set at instantiation to fault class code
 
 ///////////////////////////////////////////
@@ -41,11 +22,7 @@ STRUCT
     InUse   :   BOOL := FALSE; // If this FF is currently in-use
 ///////////////////////////////////////////
 
-    
-//    {attribute 'pytmc' := '
-//        pv: AutoReset
-//        io: i
-//     '}
+ 
     AutoReset   :   BOOL; // Automatically clear fast fault (latching vs non-latching)
     
     {attribute 'pytmc' := '

--- a/lcls-twincat-pmps/Library/DUTs/ST_FFVeto.TcDUT
+++ b/lcls-twincat-pmps/Library/DUTs/ST_FFVeto.TcDUT
@@ -34,6 +34,11 @@ STRUCT
 	Active: BOOL;
     
     Timer    :   TP;
+    VetoActLogAck : BOOL;
+    VetoExpLogAck : BOOL;
+    
+    tVetoActivate : R_TRIG;
+    tVetoExpiring  : F_TRIG;
 END_STRUCT
 END_TYPE
 ]]></Declaration>

--- a/lcls-twincat-pmps/Library/Library.plcproj
+++ b/lcls-twincat-pmps/Library/Library.plcproj
@@ -22,7 +22,6 @@
     <Description>Collection of PMPS functionality for LCLS PLCs</Description>
     <CombineIds>false</CombineIds>
     <Title>PMPS</Title>
-    <DocFormat>reStructuredText</DocFormat>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="DUTs\L_Stopper.TcTLEO">
@@ -285,8 +284,8 @@
   <ProjectExtensions>
     <PlcProjectOptions>
       <XmlArchive>
-  <Data>
-    <o xml:space="preserve" t="OptionKey">
+        <Data>
+          <o xml:space="preserve" t="OptionKey">
       <v n="Name">"&lt;ProjectRoot&gt;"</v>
       <d n="SubKeys" t="Hashtable" ckt="String" cvt="OptionKey">
         <v>{192FAD59-8248-4824-A8DE-9177C94C195A}</v>
@@ -330,14 +329,14 @@
       </d>
       <d n="Values" t="Hashtable" />
     </o>
-  </Data>
-  <TypeList>
-    <Type n="Hashtable">System.Collections.Hashtable</Type>
-    <Type n="Int32">System.Int32</Type>
-    <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
-    <Type n="String">System.String</Type>
-  </TypeList>
-</XmlArchive>
+        </Data>
+        <TypeList>
+          <Type n="Hashtable">System.Collections.Hashtable</Type>
+          <Type n="Int32">System.Int32</Type>
+          <Type n="OptionKey">{54dd0eac-a6d8-46f2-8c27-2f43c7e49861}</Type>
+          <Type n="String">System.String</Type>
+        </TypeList>
+      </XmlArchive>
     </PlcProjectOptions>
   </ProjectExtensions>
 </Project>

--- a/lcls-twincat-pmps/Library/Library.plcproj
+++ b/lcls-twincat-pmps/Library/Library.plcproj
@@ -236,6 +236,10 @@
       <DefaultResolution>Tc2_Utilities, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc2_Utilities</Namespace>
     </PlaceholderReference>
+    <PlaceholderReference Include="Tc3_JsonXml">
+      <DefaultResolution>Tc3_JsonXml, * (Beckhoff Automation GmbH)</DefaultResolution>
+      <Namespace>Tc3_JsonXml</Namespace>
+    </PlaceholderReference>
     <PlaceholderReference Include="Tc3_Module">
       <DefaultResolution>Tc3_Module, * (Beckhoff Automation GmbH)</DefaultResolution>
       <Namespace>Tc3_Module</Namespace>
@@ -280,6 +284,11 @@
   <ItemGroup>
     <PinnedGlobalDataType Include="ST_BeamParams_IO" />
     <PinnedGlobalDataType Include="ST_PMPS_Attenuator_IO" />
+  </ItemGroup>
+  <ItemGroup>
+    <PlaceholderResolution Include="Tc3_JsonXml">
+      <Resolution>Tc3_JsonXml, * (Beckhoff Automation GmbH)</Resolution>
+    </PlaceholderResolution>
   </ItemGroup>
   <ProjectExtensions>
     <PlcProjectOptions>

--- a/lcls-twincat-pmps/Library/MajorComponents/FastFaults/FB_HardwareFFOutput.TcPOU
+++ b/lcls-twincat-pmps/Library/MajorComponents/FastFaults/FB_HardwareFFOutput.TcPOU
@@ -59,11 +59,6 @@ END_VAR]]></Declaration>
     <Implementation>
       <ST><![CDATA[// <TODO> latch off beam if DI card status goes bad]]></ST>
     </Implementation>
-    <Action Name="A_EvaluateVetos" Id="{7be01ed2-4dc3-48de-b07c-613e9f301029}">
-      <Implementation>
-        <ST><![CDATA[]]></ST>
-      </Implementation>
-    </Action>
     <Action Name="EvaluateOutput" Id="{1614665f-52f0-4071-a93e-c3d94919ee5b}">
       <Implementation>
         <ST><![CDATA[
@@ -87,18 +82,68 @@ q_xFastFaultOut R= NOT xOK AND NOT i_xVeto;
 xOK := True;]]></ST>
       </Implementation>
     </Action>
+    <Action Name="EvaluateVetos" Id="{7be01ed2-4dc3-48de-b07c-613e9f301029}">
+      <Implementation>
+        <ST><![CDATA[
+FOR EvalIdx := 1 TO PMPS_GVL.MAX_FAST_FAULTS DO
+    IF NOT astFF[EvalIdx].Info.InUse THEN 
+        CONTINUE;
+    ELSE
+        // Veto timer
+        IF astFF[EvalIdx].Veto.Deactivate THEN 
+            astFF[EvalIdx].Veto.Timer.PT := T#0s; // Only needs to be set zero for one cycle
+        ELSE
+            astFF[EvalIdx].Veto.Timer.PT := UDINT_TO_TIME(astFF[EvalIdx].Veto.Duration);
+        END_IF
+        
+        // UDINT conversions for ESS module compatibility.
+        astFF[EvalIdx].Veto.Timer(
+            IN := astFF[EvalIdx].Veto.Activate, // Rising edge activated
+            Q => astFF[EvalIdx].Veto.Active);
+            
+        astFF[EvalIdx].Veto.tVetoActivate(CLK:=astFF[EvalIdx].Veto.Active);
+        astFF[EvalIdx].Veto.VetoActLogAck S= astFF[EvalIdx].Veto.tVetoActivate.Q;
+        
+        astFF[EvalIdx].Veto.tVetoExpiring(CLK:=astFF[EvalIdx].Veto.Active);
+        astFF[EvalIdx].Veto.VetoExpLogAck S= astFF[EvalIdx].Veto.tVetoExpiring.Q;
+            
+        astFF[EvalIdx].Veto.ElapsedTime := TIME_TO_UDINT(astFF[EvalIdx].Veto.Timer.ET);
+        
+        // Clear pushbuttons
+        astFF[EvalIdx].Veto.Activate := FALSE;
+        astFF[EvalIdx].Veto.Deactivate := FALSE;
+        
+    END_IF    
+END_FOR
+
+
+]]></ST>
+      </Implementation>
+    </Action>
     <Action Name="ExecuteLogging" Id="{5e96b8c8-5711-4e05-885f-92a874abdd48}">
       <Implementation>
-        <ST><![CDATA[Msg.sFormat := '%s FF %s: TypeCode %x';
+        <ST><![CDATA[
 FOR logIdx := 1 to PMPS_GVL.MAX_FAST_FAULTS do
     IF astFF[logIdx].FaultAck THEN
+        Msg.sFormat := '%s FF %s';
         Msg.arg1 := F_STRING(astFF[logIdx].Info.DevName);
         Msg.arg2 := F_STRING(astFF[logIdx].Info.sPath);
-        Msg.arg3 := F_UINT(astFF[logIdx].Info.TypeCode);
         Msg();
-        fbLogger(sMsg := Msg.sOut);
+        fbLogger(sMsg := Msg.sOut, eSevr:=TcEventSeverity.Critical, sJson:='{"pmps_typecode":1}');
         
         astFF[logIdx].FaultAck := FALSE;
+	END_IF
+    
+    IF astFF[logIdx].Veto.VetoActLogAck THEN
+        fbLogger(sMsg := 'Veto activated', eSevr:=TcEventSeverity.Warning, sJson:='{"pmps_typecode":2}');
+        
+        astFF[logIdx].Veto.VetoActLogAck := FALSE;
+	END_IF
+    
+    IF astFF[logIdx].Veto.VetoExpLogAck THEN
+        fbLogger(sMsg := 'Veto released', eSevr:=TcEventSeverity.Warning, sJson:='{"pmps_typecode":3}');
+        
+        astFF[logIdx].Veto.VetoExpLogAck := FALSE;
 	END_IF
 END_FOR
 ]]></ST>
@@ -117,20 +162,6 @@ END_VAR]]></Declaration>
       <Implementation>
         <ST><![CDATA[Idx := LIMIT(1,Idx,PMPS_GVL.MAX_FAST_FAULTS);
 stFF := THIS^.astFF[Idx];
-
-// Veto timer
-IF stFF.Veto.Deactivate THEN 
-    stFF.Veto.Timer.PT := T#0s; // Only needs to be set zero for one cycle
-ELSE
-    stFF.Veto.Timer.PT := UDINT_TO_TIME(stFF.Veto.Duration);
-END_IF
-
-// UDINT conversions for ESS module compatibility.
-stFF.Veto.Timer(
-    IN := stFF.Veto.Activate, // Rising edge activated
-    Q => stFF.Veto.Active);
-    
-stFF.Veto.ElapsedTime := TIME_TO_UDINT(stFF.Veto.Timer.ET);
 
 // Setting the log flag only on a state change.
 stFF.FaultAck S= stFF.OK AND NOT OK;
@@ -154,9 +185,7 @@ END_IF
 stFF.ftCountFault(CLK:=stFF.bsFF.Q1);
 IF stFF.ftCountFault.Q THEN PMPS_GVL.AccumulatedFF := PMPS_GVL.AccumulatedFF + 1; END_IF
 
-// Clear pushbuttons
-stFF.Veto.Activate := FALSE;
-stFF.Veto.Deactivate := FALSE;
+//Clear pushbuttons
 stFF.Reset := FALSE;
 
 // Copy state back to ff struct

--- a/lcls-twincat-pmps/Library/MajorComponents/FastFaults/FB_HardwareFFOutput.TcPOU
+++ b/lcls-twincat-pmps/Library/MajorComponents/FastFaults/FB_HardwareFFOutput.TcPOU
@@ -50,7 +50,8 @@ VAR
 	IdxOK: BOOL;
     
     logIdx : UINT := 1;
-    Msg : FB_FormatString;
+    fbJson : FB_JsonSaxWriter;
+    pmpsTypeCode : UDINT := 0; // shows up in json as pmps_typecode
     fbLogger : FB_LogMessage := (
         eSevr := TcEventSeverity.Critical,
         eSubsystem := E_Subsystem.MPS);
@@ -125,28 +126,51 @@ END_FOR
         <ST><![CDATA[
 FOR logIdx := 1 to PMPS_GVL.MAX_FAST_FAULTS do
     IF astFF[logIdx].FaultAck THEN
-        Msg.sFormat := '%s FF %s';
-        Msg.arg1 := F_STRING(astFF[logIdx].Info.DevName);
-        Msg.arg2 := F_STRING(astFF[logIdx].Info.sPath);
-        Msg();
-        fbLogger(sMsg := Msg.sOut, eSevr:=TcEventSeverity.Critical, sJson:='{"pmps_typecode":1}');
+        
+        pmpsTypeCode := 1;
+        FormulateLogJson();
+        
+        //Json is gen. in FormulateLogJson
+        fbLogger(sMsg := 'Fast Fault, beam off', eSevr:=TcEventSeverity.Critical);
         
         astFF[logIdx].FaultAck := FALSE;
 	END_IF
     
     IF astFF[logIdx].Veto.VetoActLogAck THEN
-        fbLogger(sMsg := 'Veto activated', eSevr:=TcEventSeverity.Warning, sJson:='{"pmps_typecode":2}');
+        
+        pmpsTypeCode := 2;
+        FormulateLogJson();
+        
+        fbLogger(sMsg := 'Veto activated', eSevr:=TcEventSeverity.Warning);
         
         astFF[logIdx].Veto.VetoActLogAck := FALSE;
 	END_IF
     
     IF astFF[logIdx].Veto.VetoExpLogAck THEN
-        fbLogger(sMsg := 'Veto released', eSevr:=TcEventSeverity.Warning, sJson:='{"pmps_typecode":3}');
+        
+        pmpsTypeCode := 3;
+        FormulateLogJson();
+        
+        fbLogger(sMsg := 'Veto released', eSevr:=TcEventSeverity.Warning);
         
         astFF[logIdx].Veto.VetoExpLogAck := FALSE;
 	END_IF
 END_FOR
 ]]></ST>
+      </Implementation>
+    </Action>
+    <Action Name="FormulateLogJson" Id="{e45f0264-4193-40c5-bd71-0ca588b0ef2a}">
+      <Implementation>
+        <ST><![CDATA[fbJson.StartObject();
+fbJson.AddKey("pmps_typecode");
+fbJson.AddUdint(pmpsTypeCode);
+fbJson.AddKey("pmps_path");
+fbJson.AddString(astFF[logIdx].Info.sPath);
+fbJson.AddKey("pmps_device_name");
+fbJson.AddString(astFF[logIdx].Info.DevName);
+fbJson.EndObject();
+fbLogger.sJson := fbJson.GetDocument();
+fbJson.ResetDocument();]]></ST>
       </Implementation>
     </Action>
     <Method Name="IdxCheckIn" Id="{9a63f75f-7c14-46d0-b762-024d9e3e2e01}">


### PR DESCRIPTION
Moved veto timeout/activation logic to a separate action to make fast fault evaluation leaner.

Adding logging for veto activation/deactivation.