### PR TITLE
QOL: Reduce Fast Faults

### DIFF
--- a/lcls-twincat-pmps/Library/GVLs/PMPS_GVL.TcGVL
+++ b/lcls-twincat-pmps/Library/GVLs/PMPS_GVL.TcGVL
@@ -19,7 +19,7 @@ VAR_GLOBAL CONSTANT
     VISIBLE_TEST_VELOCITY    :    LREAL    := 10;
     FAST_TEST_VELOCITY        :    LREAL    := 100;
     MAX_DEVICE_STATES        :    UDINT    := 300;
-    MAX_FAST_FAULTS : UINT := 250; // Maximum number of fast faults that can be associated with a FFO
+    MAX_FAST_FAULTS : UINT := 100; // Maximum number of fast faults that can be associated with a FFO
     
     cstFullBeam    :    ST_BeamParams := (
         fAtt := 0,


### PR DESCRIPTION
For faster IOC boots. FFO has an over estimate of fast faults.
