### PR TITLE
Features to help with troubleshooting arbiters

### DIFF
--- a/lcls-twincat-pmps/PMPS/TestComponents/FB_Arbiter_Test.TcPOU
+++ b/lcls-twincat-pmps/PMPS/TestComponents/FB_Arbiter_Test.TcPOU
@@ -250,6 +250,12 @@ AssertTrue(fbArbiter.RemoveRequest(nId),
 AssertFalse(fbArbiter.CheckRequest(nId),
     'Remove did not remove request');
     
+TEST_FINISHED();
+
+TEST('NoRequestsFullBeam');
+
+AssertFalse(F_DifferentBeamParams(fbArbiter.GetArbitratedBP(), PMPS_GVL.cstFullBeam), 'Arbitrated beam should be full with all requests removed');
+
 TEST_FINISHED();]]></ST>
       </Implementation>
     </Method>


### PR DESCRIPTION
Added a test to verify full beam is asserted when the arbiter has no requests.