### PR TITLE
Need to flag a new request when we remove as well!

### DIFF
--- a/lcls-twincat-pmps/PMPS/MajorComponents/Arbiter/FB_Arbiter.TcPOU
+++ b/lcls-twincat-pmps/PMPS/MajorComponents/Arbiter/FB_Arbiter.TcPOU
@@ -333,6 +333,9 @@ END_VAR
     END_IF
 END_IF
 
+// With any new request reset the internal arbiter "done" flag
+xRequestMade := FALSE;
+
 RemoveRequest := THIS^.fbBPAssertionPool.bOk;]]></ST>
       </Implementation>
     </Method>


### PR DESCRIPTION
This was uncovered during deployment with Zach on the motion systems (first major customer of the preemptive system).

I will need to add a test for this a bit later.

The arbiter wasn't flagging internally that something had changed upon removal of an ID and it should have.