### PR TITLE
RemoveRequest Bugfix

### DIFF
--- a/lcls-twincat-pmps/PMPS/MajorComponents/Arbiter/FB_Arbiter.TcPOU
+++ b/lcls-twincat-pmps/PMPS/MajorComponents/Arbiter/FB_Arbiter.TcPOU
@@ -269,10 +269,6 @@ ELSE
         nArbiterCohort := nArbiterCohort + 1; // This cohort number is for all subordinate requests within the arbiter
     END_IF
 END_IF
-
-
-
-
 ]]></ST>
       </Implementation>
     </Method>
@@ -386,7 +382,7 @@ VAR CONSTANT
 	BP_Int : ST_BP_ArbInternal := (nId:=0, LiveInTable:=FALSE);
 END_VAR]]></Declaration>
       <Implementation>
-        <ST><![CDATA[IF nReqId <> PMPS_GVL.EXCLUDED_ASSERTION_ID THEN
+        <ST><![CDATA[IF nReqId <> PMPS_GVL.EXCLUDED_ASSERTION_ID AND CheckRequestInPool(nReqId) THEN
 	// Include an A_Add action here to
 	// update this entry with a dummy filler (ID = 0, LiveInTable= False)
 	// before removing it since this hash

--- a/lcls-twincat-pmps/PMPS/MajorComponents/Arbiter/FB_Arbiter.TcPOU
+++ b/lcls-twincat-pmps/PMPS/MajorComponents/Arbiter/FB_Arbiter.TcPOU
@@ -402,14 +402,16 @@ END_VAR]]></Declaration>
                 eSubsystem:=E_Subsystem.MPS);
         END_IF
     END_IF
+    
+    // With any new request reset the internal arbiter "done" flag
+    xRequestMade R= THIS^.fbBPAssertionPool.bOk;
+    
+    RemoveRequest := THIS^.fbBPAssertionPool.bOk;
+    
+    nRequestsCount := nEntryCount;
+    
 END_IF
-
-// With any new request reset the internal arbiter "done" flag
-xRequestMade R= THIS^.fbBPAssertionPool.bOk;
-
-RemoveRequest := THIS^.fbBPAssertionPool.bOk;
-
-nRequestsCount := nEntryCount;]]></ST>
+]]></ST>
       </Implementation>
     </Method>
     <Method Name="RequestBP" Id="{d19219fe-34dd-4096-83ea-674a98690de1}">

--- a/lcls-twincat-pmps/PMPS/TestComponents/FB_Arbiter_Test.TcPOU
+++ b/lcls-twincat-pmps/PMPS/TestComponents/FB_Arbiter_Test.TcPOU
@@ -14,7 +14,8 @@ END_VAR
       <ST><![CDATA[Arbitration();
 RequestCheckRemoveBP();
 FullArbitrationStack();
-StackArbiters();]]></ST>
+StackArbiters();
+RemoveReq();]]></ST>
     </Implementation>
     <Method Name="ArbiterCapacity" Id="{f24e572d-11ee-48d8-ae26-2ae1990f129e}">
       <Declaration><![CDATA[METHOD ArbiterCapacity
@@ -239,6 +240,33 @@ ELSE
 END_IF
 
 ]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="RemoveReq" Id="{0f0c060b-fb07-4a71-b5b6-828444ee58c6}">
+      <Declaration><![CDATA[METHOD RemoveReq
+VAR
+    
+    Arb : FB_Arbiter(20);
+    
+    DummyHA : FB_DummyHA;
+    
+    Result : BOOL;
+    
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[
+Arb.AddRequest(30, PMPS_GVL.cst0RateBeam);
+
+Arb.ElevateRequest(DummyHA);
+
+TEST('Remove Req');
+    Result := Arb.RemoveRequest(77);
+    
+    AssertFalse( Result, 'RemoveReq returned true, with nothing to remove');
+    AssertTrue( Arb.xRequestMade , 'RequestMade has been reset. Something is wrong');
+    
+TEST_FINISHED();]]></ST>
       </Implementation>
     </Method>
     <Method Name="RequestCheckRemoveBP" Id="{62a4c245-663e-41d8-901a-0a0faba360f7}">


### PR DESCRIPTION
Found an oversight in RemoveReq which causes relentless cohort update if RemoveReq is called repeatedly.

RemoveReq should be callable under any circumstance and should have zero effect if the RequestID isn't found in the pool. 

Without this PR, when RemoveReq is called it's always guaranteed to reset the RequestMade bool which will trigger a cohort increment through the preemptive stack. API users have no reason to expect this would happen, so in some cases this method was being called on every cycle which leads to a blocked condition for preemptive requests.

This PR addresses this issue by simply checking if the request exists in the pool first. If it's not in the pool, nothing happens.