### PR TITLE
ENH: add eV bitmask calculation helper functions

### DIFF
--- a/lcls-twincat-pmps/PMPS/HelperFunctions/F_eVExcludeRange.TcPOU
+++ b/lcls-twincat-pmps/PMPS/HelperFunctions/F_eVExcludeRange.TcPOU
@@ -17,7 +17,8 @@ VAR_INPUT
     fUpper: REAL;
 END_VAR]]></Declaration>
     <Implementation>
-      <ST><![CDATA[F_eVExcludeRange := F_eVIncludeRange(0, fLower) OR F_eVIncludeRange(fUpper, PMPS_GVL.g_areVBoundaries[PMPS_GVL.g_cBoundaries]);]]></ST>
+      <ST><![CDATA[
+F_eVExcludeRange := F_eVIncludeRange(0, fLower) OR F_eVIncludeRange(fUpper, PMPS_GVL.g_areVBoundaries[PMPS_GVL.g_cBoundaries]);]]></ST>
     </Implementation>
   </POU>
 </TcPlcObject>

--- a/lcls-twincat-pmps/PMPS/HelperFunctions/F_eVExcludeRange.TcPOU
+++ b/lcls-twincat-pmps/PMPS/HelperFunctions/F_eVExcludeRange.TcPOU
@@ -1,0 +1,23 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="F_eVExcludeRange" Id="{920777a9-efc7-465f-bdbf-e4c00c8fc260}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION F_eVExcludeRange : DWORD
+(*
+    Given an lower and upper end of an exclusion range, return the corresponding eV bitmask.
+    
+    eVs between fLower and fUpper will be considered unsafe, and eVs outside of this range will be
+    considered safe, with the exception of the endpoints and values near the endpoints if they land
+    far from an eV boundary.
+    
+    Call this in your init cycle to set up your eV bitmasks for more readable code
+    that is also more resiliant to eV range definition adjustments.
+*)
+VAR_INPUT
+    fLower: REAL;
+    fUpper: REAL;
+END_VAR]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[F_eVExcludeRange := F_eVIncludeRange(0, fLower) OR F_eVIncludeRange(fUpper, PMPS_GVL.g_areVBoundaries[PMPS_GVL.g_cBoundaries]);]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/lcls-twincat-pmps/PMPS/HelperFunctions/F_eVIncludeRange.TcPOU
+++ b/lcls-twincat-pmps/PMPS/HelperFunctions/F_eVIncludeRange.TcPOU
@@ -1,0 +1,37 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+  <POU Name="F_eVIncludeRange" Id="{c20a91a5-d8f4-4cbd-939c-1b32fa327175}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION F_eVIncludeRange : DWORD
+(*
+    Given an lower and upper end of an inclusion range, return the corresponding eV bitmask.
+    
+    eVs between fLower and fUpper will be considered safe, with the exception of the endpoints and values
+    near the endpoints if they land far from an eV boundary.
+    
+    Call this in your init cycle to set up your eV bitmasks for more readable code
+    that is also more resiliant to eV range definition adjustments.
+*)
+VAR_INPUT
+    fLower: REAL;
+    fUpper: REAL;
+END_VAR
+VAR
+    nBitmask: DWORD := 0;
+    nIndex: INT;
+    nBit: USINT := 0;
+    fPrev: REAL := 0;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[FOR nIndex := 0 TO PMPS_GVL.g_cBoundaries DO
+    IF fLower <= fPrev AND fUpper >= PMPS_GVL.g_areVBoundaries[nIndex] THEN
+        nBitmask := nBitmask + SHL(1, nBit);
+	END_IF
+    fPrev := PMPS_GVL.g_areVBoundaries[nIndex];
+    nBit := nBit + 1;
+END_FOR
+
+F_eVIncludeRange := nBitmask;]]></ST>
+    </Implementation>
+  </POU>
+</TcPlcObject>

--- a/lcls-twincat-pmps/PMPS/HelperFunctions/F_eVIncludeRange.TcPOU
+++ b/lcls-twincat-pmps/PMPS/HelperFunctions/F_eVIncludeRange.TcPOU
@@ -23,10 +23,11 @@ VAR
 END_VAR
 ]]></Declaration>
     <Implementation>
-      <ST><![CDATA[FOR nIndex := 0 TO PMPS_GVL.g_cBoundaries DO
+      <ST><![CDATA[
+FOR nIndex := 0 TO PMPS_GVL.g_cBoundaries DO
     IF fLower <= fPrev AND fUpper >= PMPS_GVL.g_areVBoundaries[nIndex] THEN
         nBitmask := nBitmask + SHL(1, nBit);
-	END_IF
+    END_IF
     fPrev := PMPS_GVL.g_areVBoundaries[nIndex];
     nBit := nBit + 1;
 END_FOR

--- a/lcls-twincat-pmps/PMPS/PMPS.plcproj
+++ b/lcls-twincat-pmps/PMPS/PMPS.plcproj
@@ -122,6 +122,12 @@
       <SubType>Code</SubType>
       <LinkAlways>true</LinkAlways>
     </Compile>
+    <Compile Include="HelperFunctions\F_eVExcludeRange.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
+    <Compile Include="HelperFunctions\F_eVIncludeRange.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="HelperFunctions\F_eVRangeCalculator.TcPOU">
       <SubType>Code</SubType>
       <LinkAlways>true</LinkAlways>


### PR DESCRIPTION
Add two helper functions for generating eV bitmasks:
- F_eVIncludeRange(fLower, fUpper) -> bitmask
- F_eVExcludeRange(fLower, fUpper) -> bitmask

Uses the same algorithm as the code tested here: https://github.com/pcdshub/pcdscalc/blob/master/pcdscalc/pmps.py

Not tested on TwinCAT yet because my test plc is offline, considering testing via copying functions to lcls-plc-lfe-motion since that needs an update for PMPS anyway

closes #83