### PR TITLE
MNT: remove defunct solution items dir conflicting with docs build

### DIFF
--- a/lcls-twincat-pmps.sln
+++ b/lcls-twincat-pmps.sln
@@ -5,12 +5,6 @@ VisualStudioVersion = 15.0.28307.705
 MinimumVisualStudioVersion = 10.0.40219.1
 Project("{B1E792BE-AA5F-4E3C-8C82-674BF9C0715B}") = "lcls-twincat-pmps", "lcls-twincat-pmps\lcls-twincat-pmps.tsproj", "{975504C8-D07C-40E0-B09A-CB44983E91F3}"
 EndProject
-Project("{2150E333-8FDC-42A3-9474-1A3956D46DE8}") = "Solution Items", "Solution Items", "{937CFA37-1F4B-4ABB-867C-64DDEA6A6E09}"
-	ProjectSection(SolutionItems) = preProject
-		..\.gitattributes = ..\.gitattributes
-		..\.gitignore = ..\.gitignore
-	EndProjectSection
-EndProject
 Global
 	GlobalSection(SolutionConfigurationPlatforms) = preSolution
 		Debug|TwinCAT CE7 (ARMV7) = Debug|TwinCAT CE7 (ARMV7)
@@ -55,22 +49,6 @@ Global
 		{12553481-002F-4F4E-A6CC-B95AC65F55FF}.Release|TwinCAT RT (x64).Build.0 = Release|TwinCAT RT (x64)
 		{12553481-002F-4F4E-A6CC-B95AC65F55FF}.Release|TwinCAT RT (x86).ActiveCfg = Release|TwinCAT RT (x86)
 		{12553481-002F-4F4E-A6CC-B95AC65F55FF}.Release|TwinCAT RT (x86).Build.0 = Release|TwinCAT RT (x86)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Debug|TwinCAT CE7 (ARMV7).ActiveCfg = Debug|TwinCAT CE7 (ARMV7)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Debug|TwinCAT CE7 (ARMV7).Build.0 = Debug|TwinCAT CE7 (ARMV7)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Debug|TwinCAT OS (ARMT2).ActiveCfg = Debug|TwinCAT OS (ARMT2)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Debug|TwinCAT OS (ARMT2).Build.0 = Debug|TwinCAT OS (ARMT2)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Debug|TwinCAT RT (x64).ActiveCfg = Debug|TwinCAT RT (x64)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Debug|TwinCAT RT (x64).Build.0 = Debug|TwinCAT RT (x64)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Debug|TwinCAT RT (x86).ActiveCfg = Debug|TwinCAT RT (x86)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Debug|TwinCAT RT (x86).Build.0 = Debug|TwinCAT RT (x86)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Release|TwinCAT CE7 (ARMV7).ActiveCfg = Release|TwinCAT CE7 (ARMV7)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Release|TwinCAT CE7 (ARMV7).Build.0 = Release|TwinCAT CE7 (ARMV7)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Release|TwinCAT OS (ARMT2).ActiveCfg = Release|TwinCAT OS (ARMT2)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Release|TwinCAT OS (ARMT2).Build.0 = Release|TwinCAT OS (ARMT2)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Release|TwinCAT RT (x64).ActiveCfg = Release|TwinCAT RT (x64)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Release|TwinCAT RT (x64).Build.0 = Release|TwinCAT RT (x64)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Release|TwinCAT RT (x86).ActiveCfg = Release|TwinCAT RT (x86)
-		{F95E0922-12E0-4C0D-A087-8E9A537B3A38}.Release|TwinCAT RT (x86).Build.0 = Release|TwinCAT RT (x86)
 	EndGlobalSection
 	GlobalSection(SolutionProperties) = preSolution
 		HideSolutionNode = FALSE


### PR DESCRIPTION
In all pull requests, the docs build fails on:
```
FileNotFoundError: Path does not exist:
/home/travis/build/pcdshub/lcls-twincat-pmps/Solution Items
/home/travis/build/pcdshub/lcls-twincat-pmps/Solution Items missing
```
Upon opening the project I notice a "Solution Items" top-level folder that contains ".gitattributes" and ".gitignore". Upon trying to view either of these files, I am told that they do not exist.

I remove this folder from the solution (no option to delete, since it doesn't actually exist), and as a result the solution file changes like in this diff.

The .gitattributes and .gitignore files still exist in the repo and are active.

The docs build hopefully succeeds now that it isn't stuck looking for a missing folder.