### PR TITLE
GH: add PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -21,3 +21,4 @@
 - [ ] Code contains descriptive comments
 - [ ] Test suite passes locally
 - [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
+- [ ] Check that ``BP_IO`` parameters weren't modified unintentionally


### PR DESCRIPTION
Just a thought based on the previous PR.

* The included template would show up in each new PR we open.
* If we like this enough, we could add it to other (shared) twincat library repos. 
* A customized one would be needed for PLC projects themselves, if desirable.