### PR TITLE
FIX: Changed the Upper range for the K Value to 5.7.

### DIFF
--- a/lcls-twincat-pmps/PMPS/MajorComponents/PhotonEnergyInterface/FB_SXU.TcPOU
+++ b/lcls-twincat-pmps/PMPS/MajorComponents/PhotonEnergyInterface/FB_SXU.TcPOU
@@ -142,7 +142,7 @@ VAR CONSTANT
         pv: HiK
         io: i
     '}
-	fHiK : LREAL := 5.5; 
+	fHiK : LREAL := 5.7; 
 END_VAR
 ]]></Declaration>
     <Implementation>


### PR DESCRIPTION
FIX: Changed the Upper range for the K Value to 5.7 as per Jira ticket LCLSECSD-987

<!--- Provide a general summary of your changes in the Title above -->
(https://jira.slac.stanford.edu/browse/LCLSECSD-987)
The Upper K value for the SXR undulators was 5.5. There was a request to change it to 5.7.
The Jira ticket also included change to the HXR, but that change was already implemented, so I updated the confluence page with the library values. https://confluence.slac.stanford.edu/display/L2SI/PMPS+Photon+Energy
[<!--- Describe your changes in detail -->]
K-Ranges For SXU function block. 
{attribute 'pytmc' := '
    pv: HiK
    io: i
'}
fHiK : LREAL := 5.7;

## Motivation and Context
https://slac.slack.com/archives/CUC9NLU8H/p1649207045123829

## How Has This Been Tested?
Not yet tested.

## Where Has This Been Documented?
(https://confluence.slac.stanford.edu/pages/viewpage.action?pageId=343703604)

## Pre-merge checklist
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
- [ ] Check that ``BP_IO`` parameters weren't modified unintentionally
