### PR TITLE
Dev: The undulator period is now a PV. 

### DIFF
--- a/lcls-twincat-pmps/PMPS/MajorComponents/PhotonEnergyInterface/FB_SXU.TcPOU
+++ b/lcls-twincat-pmps/PMPS/MajorComponents/PhotonEnergyInterface/FB_SXU.TcPOU
@@ -183,6 +183,7 @@ FOR iIndex := iLowBound TO iHighBound DO
     IF fbSegment[iIndex] <> 0 THEN
         fbCurrentSegment REF= fbSegment[iIndex]^;
         fbCurrentSegment(fbElectronEnergy:=fbElectronEnergy);
+        fbCurrentSegment.fPeriod_mm := fbCurrentSegment.fLambda_U*1000;
 
         //Mark the seed undulator, first undulator operating within K bounds
         IF fbCurrentSegment.xActive AND nSeedUndulator = 0 THEN
@@ -215,9 +216,6 @@ FOR iIndex := iLowBound TO iHighBound DO
         fbCurrentSegment REF= fbSegment[iIndex]^;
         fbCurrentSegment.fLowK := fLowK;
         fbCurrentSegment.fHiK := fHiK;
-        IF (iIndex >= 26)  THEN fbCurrentSegment.fPeriod_mm := fPeriod_39_mm;
-            ELSE fbCurrentSegment.fPeriod_mm := fPeriod_56_mm;
-        END_IF
     END_IF
 END_FOR
 bInitialized := TRUE;]]></ST>
@@ -247,7 +245,7 @@ END_VAR
     </Property>
     <Action Name="UndAdrUpdate" Id="{9de2fd9a-9f44-4b71-9e83-edd38b0d7037}">
       <Implementation>
-        <ST><![CDATA[fbSegment[21] := ADR(fbSegment_21);
+        <ST><![CDATA[fbSegment[21] := 0;
 fbSegment[22] := ADR(fbSegment_22);
 fbSegment[23] := ADR(fbSegment_23);
 fbSegment[24] := ADR(fbSegment_24);

--- a/lcls-twincat-pmps/PMPS/MajorComponents/PhotonEnergyInterface/FB_UndulatorSegment.TcPOU
+++ b/lcls-twincat-pmps/PMPS/MajorComponents/PhotonEnergyInterface/FB_UndulatorSegment.TcPOU
@@ -3,8 +3,9 @@
   <POU Name="FB_UndulatorSegment" Id="{986484f4-a7ca-4f8c-bada-b360e7740d21}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_UndulatorSegment
 VAR_INPUT
-    (* Undulator period in millimeters, to be set by subclasses *)
+    (* Undulator period in millimeters, to be set by subclasses for HXR, read by pv for SXR, left here for backward compatability *)
     fPeriod_mm : LREAL := 1.0;
+
     fbElectronEnergy : REFERENCE TO FB_LREALFromEPICS;
 
     fLowK : LREAL := 0;
@@ -57,7 +58,14 @@ VAR_OUTPUT
     '}
     fKDes : LREAL;
 
-        {attribute 'pytmc' := '
+    {attribute 'pytmc' := '
+        pv: Lambda_U
+        io: i
+        field: DESC Period in m
+    '}
+    fLambda_U : LREAL;
+
+    {attribute 'pytmc' := '
         pv: KActValid
         io: i
         field: DESC Current K Readback Valid
@@ -70,6 +78,14 @@ VAR_OUTPUT
         field: DESC Target K Readback Valid
     '}
     bKDesValid : BOOL;
+
+     {attribute 'pytmc' := '
+        pv: lambdaValid
+        io: i
+        field: DESC lambda_U Readback Valid
+    '}
+    blambdaValid : BOOL;
+
 
 END_VAR
 
@@ -86,20 +102,29 @@ VAR
     '}
     fbKActual : FB_LREALFromEPICS;
 
+    {attribute 'pytmc' := '
+        pv: lambda_U
+        link: lambda_U
+    '}
+    fblambda_U : FB_LREALFromEPICS;
+
 END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[fbKDesired();
 fbKActual();
+fblambda_U();
 
 fKAct := fbKActual.fValue;
 bKActValid := fbKActual.bValid;
 fKDes := fbKDesired.fValue;
 bKDesValid := fbKDesired.bvalid;
+fLambda_U := fblambda_U.fValue;
+blambdaValid:= fblambda_U.bValid;
 
 IF __ISVALIDREF(fbElectronEnergy) THEN
 
-    IF fbKActual.bValid AND fbElectronEnergy.bValid THEN
+    IF fbKActual.bValid AND fblambda_U.bValid AND fbElectronEnergy.bValid THEN
         fPhotonEnergyAct := F_CalculatePhotonEnergy(
             fElectronEnergy_GeV:=fbElectronEnergy.fValue,
             fUndulatorPeriod_mm:=fPeriod_mm,
@@ -119,7 +144,7 @@ IF __ISVALIDREF(fbElectronEnergy) THEN
                     (NOT fbKDesired.bValid OR NOT fbKDesired.bValid);
     END_IF
 
-    IF fbKDesired.bValid AND fbElectronEnergy.bValid THEN
+    IF fbKDesired.bValid AND fblambda_U.bValid AND fbElectronEnergy.bValid THEN
         fPhotonEnergyDes := F_CalculatePhotonEnergy(
             fElectronEnergy_GeV:=fbElectronEnergy.fValue,
             fUndulatorPeriod_mm:=fPeriod_mm,

--- a/lcls-twincat-pmps/PMPS/PMPS.plcproj
+++ b/lcls-twincat-pmps/PMPS/PMPS.plcproj
@@ -16,7 +16,7 @@
     <Implicit_Jitter_Distribution>{9571b800-3cbb-4490-9af6-a1013ff71bd1}</Implicit_Jitter_Distribution>
     <LibraryReferences>{1c1d8a93-1736-437e-b538-e21ada2f6c38}</LibraryReferences>
     <Company>SLAC - LCLS</Company>
-    <Released>false</Released>
+    <Released>true</Released>
     <Author>Alex Wallace and contributors</Author>
     <Description>Collection of PMPS functionality for LCLS PLCs</Description>
     <CombineIds>false</CombineIds>
@@ -33,7 +33,7 @@
         </Event>
       </Events>
     </DeploymentEvents>
-    <ProjectVersion>0.0.0</ProjectVersion>
+    <ProjectVersion>3.5.0</ProjectVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AncillaryComponents\FB_JsonDocToSafeBP.TcPOU">

--- a/lcls-twincat-pmps/PMPS/PMPS.plcproj
+++ b/lcls-twincat-pmps/PMPS/PMPS.plcproj
@@ -16,7 +16,7 @@
     <Implicit_Jitter_Distribution>{9571b800-3cbb-4490-9af6-a1013ff71bd1}</Implicit_Jitter_Distribution>
     <LibraryReferences>{1c1d8a93-1736-437e-b538-e21ada2f6c38}</LibraryReferences>
     <Company>SLAC - LCLS</Company>
-    <Released>true</Released>
+    <Released>false</Released>
     <Author>Alex Wallace and contributors</Author>
     <Description>Collection of PMPS functionality for LCLS PLCs</Description>
     <CombineIds>false</CombineIds>
@@ -33,7 +33,7 @@
         </Event>
       </Events>
     </DeploymentEvents>
-    <ProjectVersion>3.5.0</ProjectVersion>
+    <ProjectVersion>0.0.0</ProjectVersion>
   </PropertyGroup>
   <ItemGroup>
     <Compile Include="AncillaryComponents\FB_JsonDocToSafeBP.TcPOU">

--- a/lcls-twincat-pmps/PMPS/PMPS.tmc
+++ b/lcls-twincat-pmps/PMPS/PMPS.tmc
@@ -31494,7 +31494,7 @@ request loop (two arbiters elevating to each other), or there is a RequestAdd, R
         </Property>
         <Property>
           <Name>ChangeDate</Name>
-          <Value>2025-02-25T20:14:40</Value>
+          <Value>2025-04-01T13:46:17</Value>
         </Property>
         <Property>
           <Name>GeneratedCodeSize</Name>


### PR DESCRIPTION


<!--- Provide a general summary of your changes in the Title above -->
## Description
Every undulator has a pv:lambda_U in m. The library changes now reads the pv and write it to the period_mm variable. maintaining backward compatibility for HXR undulators.

## Motivation and Context
Every undulator has a pv:lambda_U in m

## How Has This Been Tested?
deployed in the lfe-arbiter and seems to be working fine.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [x] Code works interactively
- [x] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
- [x] Check that ``BP_IO`` parameters weren't modified unintentionally
