### PR TITLE
Updating BPComparisonTran for new TRANS_MARGIN

### DIFF
--- a/lcls-twincat-pmps/PMPS/TestComponents/FB_SafeBPCompare_Test.TcPOU
+++ b/lcls-twincat-pmps/PMPS/TestComponents/FB_SafeBPCompare_Test.TcPOU
@@ -156,7 +156,7 @@ stSafer := F_SetBeamParams(
     PMPS_GVL.DUMMY_AUX_ATT_ARRAY);
 
 stNotSoSafe := F_SetBeamParams(
-    0.61, //
+    0.62, //
     16#FFFFFFFF,
     1,
     16#0000,
@@ -171,7 +171,7 @@ AssertFalse(
     'Attenuation eval is broken (False)');
 
 // Check at margin threshold
-stSafer.nTran := stNotSoSafe.nTran*(PMPS_GVL.TRANS_SCALING_FACTOR + PMPS_PARAM.TRANS_MARGIN)/PMPS_GVL.TRANS_SCALING_FACTOR;
+stSafer.nTran := 0.99 * stNotSoSafe.nTran*(PMPS_GVL.TRANS_SCALING_FACTOR + PMPS_PARAM.TRANS_MARGIN)/PMPS_GVL.TRANS_SCALING_FACTOR;
 AssertTrue(
     F_SafeBPCompare(stSafer, stNotSoSafe),
     'Attenuation eval is broken: should be safe up to margin.');


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Changed stNotSoSafe.nTran to 0.62. It was initally 0.61, and is meant to be more than 120% of stSafer.nTran which is initially 0.51 to cause F_SafeBPCompare to return false. 0.51 * 1.2 = 0.612

The change on line 174 was because I was failing the the succeeding assertion due to floating point error when it was trying to set stSafer.nTran to exactly (stNotSoSafe.nTran * 1.2) so I added the 0.99 as a deflater. 

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
I forgot to run the unit tests before I merged #134. I can't think of anything else that needs to be updated because of the change to TRANS_MARGIN. 

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
I ran the tests and they all passed.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [x] Test suite passes locally
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
- [ ] Check that ``BP_IO`` parameters weren't modified unintentionally
