### PR TITLE
Adding abstract StopperVetoable

### DIFF
--- a/lcls-twincat-pmps/PMPS/DUTs/InternalDUT/K_Stopper.TcDUT
+++ b/lcls-twincat-pmps/PMPS/DUTs/InternalDUT/K_Stopper.TcDUT
@@ -17,7 +17,7 @@ TYPE K_Stopper :
     MR2K3_IN := 10, // TXI MR2K3 Offset Mirror state
     MR2K3_OUT := 11, // TXI MR2K3 Offset Mirror horizontal state
     DEFAULT := PMPS_GVL.MAX_VETO_DEVICES // DO NOT USE FOR ANYTHING
-);
+)WORD;
 END_TYPE
 ]]></Declaration>
   </DUT>

--- a/lcls-twincat-pmps/PMPS/DUTs/InternalDUT/L_Stopper.TcDUT
+++ b/lcls-twincat-pmps/PMPS/DUTs/InternalDUT/L_Stopper.TcDUT
@@ -12,7 +12,7 @@ TYPE L_Stopper :
     MR1L1_IN:= 5, //  TXI Offset Mirror horizontal state
     MR1L1_OUT:= 6, // TXI Offset Mirror horizontal state
     DEFAULT := PMPS_GVL.MAX_VETO_DEVICES // DO NOT USE FOR ANYTHING
-);
+)WORD;
 END_TYPE
 ]]></Declaration>
   </DUT>

--- a/lcls-twincat-pmps/PMPS/GVLs/PMPS_GVL.TcGVL
+++ b/lcls-twincat-pmps/PMPS/GVLs/PMPS_GVL.TcGVL
@@ -210,6 +210,30 @@ VAR_GLOBAL CONSTANT
     7.00E3
     ];
 
+    L_Stopper_Pairings : ARRAY[1..PMPS_GVL.MAX_VETO_DEVICES] OF L_STOPPER :=
+    [
+    L_Stopper.DEFAULT,		// L_Stopper.ST1L0
+    L_Stopper.DEFAULT, 		// L_Stopper.ST1L1
+    L_Stopper.MR1L0_TXI, 	// L_Stopper.MR1L0_L0
+    L_Stopper.MR1L0_L0, 	// L_Stopper.MR1L0_TXI
+    L_Stopper.MR1L1_OUT,	// L_Stopper.MR1L1_IN
+    L_Stopper.MR1L1_IN  	// L_Stopper.MR1L1_OUT
+    ];
+
+    K_Stopper_Pairings : ARRAY[1..PMPS_GVL.MAX_VETO_DEVICES] OF K_STOPPER :=
+    [
+    K_Stopper.DEFAULT,		// ST3K4
+    K_Stopper.DEFAULT,		// ST1K2
+    K_Stopper.MR1K1_OUT,	// MR1K1_IN
+    K_Stopper.MR1K1_IN,		// MR1K1_OUT
+    K_Stopper.MR1K3_OUT,	// MR1K3_IN
+    K_Stopper.MR1K3_IN,		// MR1K3_OUT
+    K_Stopper.DEFAULT,		// ST4K4
+    K_Stopper.DEFAULT,		// ST1K4
+    K_Stopper.DEFAULT,		// ST1K3
+    K_Stopper.MR2K3_OUT,	// MR2K3_IN
+    K_Stopper.MR2K3_IN		// MR2K3_OUT
+    ];
 
 END_VAR]]></Declaration>
   </GVL>

--- a/lcls-twincat-pmps/PMPS/MajorComponents/Arbiter/FB_VetoArbiter.TcPOU
+++ b/lcls-twincat-pmps/PMPS/MajorComponents/Arbiter/FB_VetoArbiter.TcPOU
@@ -1,7 +1,7 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
 <TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
   <POU Name="FB_VetoArbiter" Id="{c3c91f40-d3bf-4445-afff-e5f72e704ac3}" SpecialFunc="None">
-    <Declaration><![CDATA[FUNCTION_BLOCK FB_VetoArbiter IMPLEMENTS I_HigherAuthority
+    <Declaration><![CDATA[FUNCTION_BLOCK FB_VetoArbiter EXTENDS FB_StopperVetoable IMPLEMENTS I_HigherAuthority
 VAR_INPUT
     bVeto : BOOL := FALSE; // Rising edge clears request, hold true to veto continuously, falling edge restores request
     HigherAuthority : I_HigherAuthority; // Typically connected to a higher-level arbiter.
@@ -30,6 +30,7 @@ END_VAR
 ]]></Declaration>
     <Implementation>
       <ST><![CDATA[
+bVeto := bVeto OR CheckStoppers();
 rtVeto(CLK:=bVeto);
 ftVeto(CLK:=bVeto);
 LowerAuthority.bLowerAuthorityVetoed := bVeto;

--- a/lcls-twincat-pmps/PMPS/MajorComponents/FB_StopperVetoable.TcPOU
+++ b/lcls-twincat-pmps/PMPS/MajorComponents/FB_StopperVetoable.TcPOU
@@ -1,0 +1,53 @@
+﻿<?xml version="1.0" encoding="utf-8"?>
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4026.12">
+  <POU Name="FB_StopperVetoable" Id="{9114ce33-096d-4859-8327-51a29b1b7c16}" SpecialFunc="None">
+    <Declaration><![CDATA[FUNCTION_BLOCK ABSTRACT FB_StopperVetoable
+VAR
+    {attribute 'pytmc' := '
+        pv: StopperMask
+        io: i
+        field: DESC Bitmask of stoppers that veto this
+    '}
+    wStopperMask : WORD;
+END_VAR
+]]></Declaration>
+    <Implementation>
+      <ST><![CDATA[]]></ST>
+    </Implementation>
+    <Method Name="AddStopper" Id="{dfc9400d-efbb-4f3c-bb34-86649ddea037}">
+      <Declaration><![CDATA[METHOD AddStopper : BOOL
+VAR_INPUT
+    wStopper: WORD;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[AddStopper := WORD_TO_BOOL(wStopperMask AND SHL(WORD#1, wStopper));
+wStopperMask := wStopperMask OR SHL(WORD#1, wStopper);]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="CheckStoppers" Id="{1e391055-0614-47cf-92fe-50cbf0483ad1}">
+      <Declaration><![CDATA[METHOD CheckStoppers : BOOL
+VAR
+    i: WORD;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[FOR i:=1 TO PMPS_GVL.MAX_VETO_DEVICES BY 1 DO
+    CheckStoppers := CheckStoppers OR (PMPS_GVL.stCurrentBeamParameters.aVetoDevices[i] AND WORD_TO_BOOL(wStopperMask AND SHL(WORD#1, i)));
+END_FOR
+]]></ST>
+      </Implementation>
+    </Method>
+    <Method Name="RemoveStopper" Id="{00072576-a6e6-4097-9bd8-6246e1ae5421}">
+      <Declaration><![CDATA[METHOD RemoveStopper : BOOL
+VAR_INPUT
+    wStopper: WORD;
+END_VAR
+]]></Declaration>
+      <Implementation>
+        <ST><![CDATA[RemoveStopper := WORD_TO_BOOL(wStopperMask AND SHL(WORD#1, wStopper));
+wStopperMask := wStopperMask AND NOT SHL(WORD#1, wStopper);]]></ST>
+      </Implementation>
+    </Method>
+  </POU>
+</TcPlcObject>

--- a/lcls-twincat-pmps/PMPS/MajorComponents/FB_StopperVetoable.TcPOU
+++ b/lcls-twincat-pmps/PMPS/MajorComponents/FB_StopperVetoable.TcPOU
@@ -9,6 +9,7 @@ VAR
         field: DESC Bitmask of stoppers that veto this
     '}
     wStopperMask : WORD;
+    fbLog : FB_LogMessage;
 END_VAR
 ]]></Declaration>
     <Implementation>
@@ -29,11 +30,33 @@ wStopperMask := wStopperMask OR SHL(WORD#1, wStopper);]]></ST>
       <Declaration><![CDATA[METHOD CheckStoppers : BOOL
 VAR
     i: WORD;
+
+    StopperPairing : ARRAY[1..PMPS_GVL.MAX_VETO_DEVICES] OF WORD;
 END_VAR
 ]]></Declaration>
       <Implementation>
-        <ST><![CDATA[FOR i:=1 TO PMPS_GVL.MAX_VETO_DEVICES BY 1 DO
-    CheckStoppers := CheckStoppers OR (PMPS_GVL.stCurrentBeamParameters.aVetoDevices[i] AND WORD_TO_BOOL(wStopperMask AND SHL(WORD#1, i)));
+        <ST><![CDATA[CheckStoppers := FALSE;
+{IF defined (K)}
+    StopperPairing := PMPS_GVL.K_Stopper_Pairings;
+{ELSIF defined (L)}
+    StopperPairing := PMPS_GVL.L_Stopper_Pairings;
+{ELSE}
+    fbLog(sMsg := 'K/L compiler definition missing.', eSevr := TcEventSeverity.Critical);
+    RETURN;
+{END_IF}
+
+FOR i:=1 TO (PMPS_GVL.MAX_VETO_DEVICES-1) BY 1 DO
+    IF PMPS_GVL.stCurrentBeamParameters.aVetoDevices[i] AND WORD_TO_BOOL(wStopperMask AND SHL(WORD#1, i)) THEN
+        IF StopperPairing[i] <> 0 AND StopperPairing[i] <> PMPS_GVL.MAX_VETO_DEVICES THEN
+            IF NOT PMPS_GVL.stCurrentBeamParameters.aVetoDevices[StopperPairing[i]] AND NOT WORD_TO_BOOL(wStopperMask AND SHL(WORD#1, StopperPairing[i])) THEN
+                CheckStoppers := TRUE;
+                RETURN;
+            END_IF
+        ELSE
+            CheckStoppers := TRUE;
+            RETURN;
+        END_IF
+    END_IF
 END_FOR
 ]]></ST>
       </Implementation>

--- a/lcls-twincat-pmps/PMPS/MajorComponents/FastFaults/FB_HardwareFFOutput.TcPOU
+++ b/lcls-twincat-pmps/PMPS/MajorComponents/FastFaults/FB_HardwareFFOutput.TcPOU
@@ -3,7 +3,7 @@
   <POU Name="FB_HardwareFFOutput" Id="{4c5345fc-1911-455c-a3d8-14bade73dcd8}" SpecialFunc="None">
     <Declaration><![CDATA[{attribute 'reflection'}
 {attribute 'no_check'}
-FUNCTION_BLOCK FB_HardwareFFOutput
+FUNCTION_BLOCK FB_HardwareFFOutput EXTENDS FB_StopperVetoable
 VAR CONSTANT
     FF_ARRAY_UPPER_BOUND : UINT := PMPS_PARAM.MAX_FAST_FAULTS;
 END_VAR
@@ -324,7 +324,7 @@ stFF.rtReset(CLK:=stFF.Reset (*epics*) OR Reset (*from other PLC logic *) );
 stFF.Reset R= stFF.rtReset.Q;
 stFF.bsFF(SET := stFF.rtReset.Q OR stFF.Info.AutoReset, RESET1:= NOT OK);
 
-BeamPermitted := stFF.bsFF.Q1 OR stFF.Ovrd.Active OR (i_xVeto AND stFF.Info.Vetoable);
+BeamPermitted := stFF.bsFF.Q1 OR stFF.Ovrd.Active OR ((i_xVeto OR CheckStoppers()) AND stFF.Info.Vetoable);
 
 // Fault generation
 IF NOT BeamPermitted THEN

--- a/lcls-twincat-pmps/PMPS/PMPS.plcproj
+++ b/lcls-twincat-pmps/PMPS/PMPS.plcproj
@@ -270,6 +270,9 @@
     <Compile Include="MajorComponents\FB_BeamClassFromEPICS.TcPOU">
       <SubType>Code</SubType>
     </Compile>
+    <Compile Include="MajorComponents\FB_StopperVetoable.TcPOU">
+      <SubType>Code</SubType>
+    </Compile>
     <Compile Include="MajorComponents\I_LowerAuthority.TcIO">
       <SubType>Code</SubType>
     </Compile>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Added an abstract class FB_StopperVetoable (name subject to change) which has a WORD var representing a bitmask and three methods - AddStopper, RemoveStopper, and CheckStoppers. The intention is that instead of manually creating a boolean variable and passing it to VetoArbiters and FFOs, you can make calls like `AddStopper(PMPS.K_Stopper.MR1K1_OUT)`. The bitmask will be evaluated at the same time as their normal veto variables. Finally, this bitmask will be exposed as a PV which allow the pmps gui to display information like which stoppers will affect a specific arbiter or ffo and how, and by extension all the devices they represent.

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-3702

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->

## Pre-merge checklist
- [ ] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [ ] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
- [ ] Check that ``BP_IO`` parameters weren't modified unintentionally
