### PR TITLE
MNT: switch SXU lowk to 1.52 as per request

### DIFF
--- a/lcls-twincat-pmps/PMPS/MajorComponents/PhotonEnergyInterface/FB_SXU.TcPOU
+++ b/lcls-twincat-pmps/PMPS/MajorComponents/PhotonEnergyInterface/FB_SXU.TcPOU
@@ -1,5 +1,5 @@
 ﻿<?xml version="1.0" encoding="utf-8"?>
-<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4022.18">
+<TcPlcObject Version="1.1.0.1" ProductVersion="3.1.4024.12">
   <POU Name="FB_SXU" Id="{23188e56-6a28-4c8b-9089-611f5a306284}" SpecialFunc="None">
     <Declaration><![CDATA[FUNCTION_BLOCK FB_SXU IMPLEMENTS I_UndulatorComplex
 VAR_INPUT
@@ -158,7 +158,7 @@ VAR CONSTANT
         pv: LowK
         io: i
     '}
-    fLowK : LREAL := 0.8;
+    fLowK : LREAL := 1.52;
 
     {attribute 'pytmc' := '
         pv: HiK

--- a/lcls-twincat-pmps/_Config/PLC/PMPS.xti
+++ b/lcls-twincat-pmps/_Config/PLC/PMPS.xti
@@ -1,24 +1,20 @@
-<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
-<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmItem" TcSmVersion="1.0" TcVersion="3.1.4022.30" ClassName="CNestedPlcProjDef">
+<?xml version="1.0"?>
+<TcSmItem xmlns:xsi="http://www.w3.org/2001/XMLSchema-instance" xsi:noNamespaceSchemaLocation="http://www.beckhoff.com/schemas/2012/07/TcSmProject" TcSmVersion="1.0" TcVersion="3.1.4024.35" ClassName="CNestedPlcProjDef">
 	<Project GUID="{12553481-002F-4F4E-A6CC-B95AC65F55FF}" Name="PMPS" PrjFilePath="..\..\PMPS\PMPS.plcproj" TmcFilePath="..\..\PMPS\PMPS.tmc" ReloadTmc="true" AmsPort="851" FileArchiveSettings="#x000e" SymbolicMapping="true">
-		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="PMPS\PMPS.tmc">
+		<Instance Id="#x08502000" TcSmClass="TComPlcObjDef" KeepUnrestoredLinks="2" TmcPath="PMPS\PMPS.tmc" TmcHash="{F341AFC6-60CF-7873-BC77-B7CF37307052}">
 			<Name>PMPS Instance</Name>
 			<CLSID ClassFactory="TcPlc30">{08500001-0000-0000-F000-000000000064}</CLSID>
-			<Vars VarGrpType="8">
+			<Vars VarGrpType="8" AreaNo="4">
 				<Name>PlcTask Retains</Name>
 				<Var>
 					<Name>PMPS_GVL.SuccessfulPreemption</Name>
-					<Comment>
-						<![CDATA[ Any time BPTM applies a new BP request which is confirmed]]>
-					</Comment>
+					<Comment><![CDATA[ Any time BPTM applies a new BP request which is confirmed]]></Comment>
 					<Type>UDINT</Type>
 					<InOut>7</InOut>
 				</Var>
 				<Var>
 					<Name>PMPS_GVL.AccumulatedFF</Name>
-					<Comment>
-						<![CDATA[ Any time a FF occurs]]>
-					</Comment>
+					<Comment><![CDATA[ Any time a FF occurs]]></Comment>
 					<Type>UDINT</Type>
 					<InOut>7</InOut>
 				</Var>
@@ -28,6 +24,17 @@
 					<InOut>7</InOut>
 				</Var>
 			</Vars>
+			<Contexts>
+				<Context>
+					<Id NeedCalleeCall="true">0</Id>
+					<Name>PlcTask</Name>
+					<ManualConfig>
+						<OTCID>#x02010030</OTCID>
+					</ManualConfig>
+					<Priority>20</Priority>
+					<CycleTime>10000000</CycleTime>
+				</Context>
+			</Contexts>
 			<TaskPouOids>
 				<TaskPouOid Prio="20" OTCID="#x08502001"/>
 			</TaskPouOids>


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->
## Description
<!--- Describe your changes in detail -->
Change the Low K value in the SXU function block from 0.8 to 1.52
Other changes are incidental- blame TwinCAT

## Motivation and Context
<!--- Why is this change required? What problem does it solve? -->
<!--- If it fixes an open issue, please link to the issue here. -->
https://jira.slac.stanford.edu/browse/ECS-10169

## How Has This Been Tested?
<!--- Please describe in detail how you tested your changes. -->
<!--- Include details of your testing environment, and the tests you ran to -->
<!--- see how your change affects other areas of the code, etc. -->
Not at all!
There are no real code changes here- I'm simply changing a config parameter as requested.

## Where Has This Been Documented?
<!--  Include where the changes made have been documented. -->
<!--  This can simply be  a comment in the code or updating a docstring -->
Here, in the jira linked above, and also in https://confluence.slac.stanford.edu/spaces/PCDS/pages/691683582/2026-04-15+Photon+energy+calculation+change+-+KLow+for+SXR+undulators

## Pre-merge checklist
- [x] Libraries are set to ``Always Newest`` version (``Library, *``)
- [ ] Code works interactively
- [ ] Code contains descriptive comments
- [ ] Test suite passes locally
- [x] Committed with ``pre-commit`` or ran ``pre-commit run --all-files``
- [x] Check that ``BP_IO`` parameters weren't modified unintentionally
